### PR TITLE
Adds PyCharm settings to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ ENV/
 
 # Database
 db.sqlite3
+
+# PyCharm
+.idea/


### PR DESCRIPTION
PyCharm stores his "per project settings" inside `.idea/` folder. Would be nice to include it to the `.gitignore` so I'll not commit the directory by accident. Thanks = )