### PR TITLE
README and Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+# Travis CI settings
+
+language: python
+
+python:
+  - '3.5'
+
+install:
+  - pip install Django
+
+script:
+  - python src/manage.py test

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# django-book-trading-club
+
+Book trading web application powered by Django
+
+## Tests
+
+To run unit tests:
+
+```bash
+python manage.py test
+```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/AlekseiAQ/django-book-trading-club.svg)](https://travis-ci.org/AlekseiAQ/django-book-trading-club)
+
 # django-book-trading-club
 
 Book trading web application powered by Django


### PR DESCRIPTION
@AlekseiAQ This pull request contains basic `README.md` file and Travis CI integration for the project.

Travis integration is very simple, we just need to include the `.travis.yml` file with basic configuration (language, version, what needs to be installed before running tests, exact command to run tests) in our project (more detailed information about Travis setup for Python projects may be found here: https://docs.travis-ci.com/user/languages/python/).

To enable integration you need to log in at https://travis-ci.org/ with your github account and enable builds for the `django-book-trading-club` project.

After that Travis will start running test upon each commit in the project repository.

I also added the build status badge to the README to show the current status of the Travis build (ok, failed, unknown).

Please contact me if there would be any problems with integration activation.